### PR TITLE
Don't block if grade table missing

### DIFF
--- a/src/components/FileUploader.tsx
+++ b/src/components/FileUploader.tsx
@@ -105,7 +105,9 @@ const FileUploader: React.FC<FileUploaderProps> = ({
           // TODO : transformer 'table' en JSON et le passer à votre processStatistics(data)
         } catch (err) {
           console.warn(`Impossible d'extraire le tableau de ${file.name}`, err);
-          throw new Error("Erreur lors de l'extraction du tableau. Vérifiez le format de vos fichiers.");
+          toast.warning(
+            "Erreur lors de l'extraction du tableau. Le fichier sera traité sans ces informations."
+          );
         }
 
         try {


### PR DESCRIPTION
## Summary
- swallow failures from `extractGradesTable` during validation

## Testing
- `bun run lint` *(fails: Unexpected any)*
- `bun run build`

------
https://chatgpt.com/codex/tasks/task_e_6842f3e820d48329b8e8acd61c5312cd