### PR TITLE
Fix pdf.js worker mismatch

### DIFF
--- a/src/utils/file-parsers.ts
+++ b/src/utils/file-parsers.ts
@@ -540,19 +540,10 @@ export const parseCsvFile = async (file: File): Promise<ParsedFileData> => {
   });
 };
 
-const PDFWorker = `
-  self.onmessage = function(event) {
-    const data = event.data;
-    if (data.type === 'process') {
-      self.postMessage({ type: 'processed', success: true });
-    }
-  };
-`;
-
-const blob = new Blob([PDFWorker], { type: 'application/javascript' });
-const workerUrl = URL.createObjectURL(blob);
-
-pdfjs.GlobalWorkerOptions.workerSrc = workerUrl;
+// Use the official pdf.js worker from CDN. This avoids version mismatches and
+// ensures the worker has the correct implementation.
+pdfjs.GlobalWorkerOptions.workerSrc =
+  "https://cdnjs.cloudflare.com/ajax/libs/pdf.js/5.0.375/pdf.worker.min.js";
 
 export const parsePdfFile = async (file: File): Promise<ParsedFileData> => {
   try {

--- a/src/utils/pdf-processing.ts
+++ b/src/utils/pdf-processing.ts
@@ -66,7 +66,8 @@ async function parseGradeTable(
     
     // Load PDF with pdfjs
     // Make sure the worker is properly loaded
-    const workerSrc = "https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.4.120/pdf.worker.min.js";
+    // Use the same version as the installed pdfjs-dist package
+    const workerSrc = "https://cdnjs.cloudflare.com/ajax/libs/pdf.js/5.0.375/pdf.worker.min.js";
     
     if (!pdfjs.GlobalWorkerOptions.workerSrc) {
       pdfjs.GlobalWorkerOptions.workerSrc = workerSrc;

--- a/src/utils/pdf-service.ts
+++ b/src/utils/pdf-service.ts
@@ -1,7 +1,8 @@
 import * as pdfjs from 'pdfjs-dist';
 
 // Set the worker source for PDF.js
-const PDFJS_CDN_URL = "https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.4.120";
+// Use the same version as the pdfjs-dist package to avoid worker/version mismatch
+const PDFJS_CDN_URL = "https://cdnjs.cloudflare.com/ajax/libs/pdf.js/5.0.375";
 
 /**
  * Initialize PDF.js worker

--- a/src/utils/pdfTableExtractor.ts
+++ b/src/utils/pdfTableExtractor.ts
@@ -6,7 +6,8 @@ export async function extractGradesTable(pdfBuffer: ArrayBuffer) {
     
     // Initialize PDF.js
     if (!pdfjs.GlobalWorkerOptions.workerSrc) {
-      pdfjs.GlobalWorkerOptions.workerSrc = "https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.4.120/pdf.worker.min.js";
+      // Match the worker version with the installed pdfjs-dist package
+      pdfjs.GlobalWorkerOptions.workerSrc = "https://cdnjs.cloudflare.com/ajax/libs/pdf.js/5.0.375/pdf.worker.min.js";
     }
     
     // Load the PDF document


### PR DESCRIPTION
## Summary
- update all pdf worker references to version 5.0.375

## Testing
- `npm run lint` *(fails: many existing lint errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6842f73c8b0c8329bb7b7dee6b0b93cf