### PR TITLE
Fix PDF worker version

### DIFF
--- a/src/utils/pdf-processing.ts
+++ b/src/utils/pdf-processing.ts
@@ -1,7 +1,7 @@
 import * as pdfjs from 'pdfjs-dist';
 import { toast } from 'sonner';
 import { OpenAIService } from './openai-service';
-import { extractTextFromPDF, validatePdfFile } from './pdf-service';
+import { extractTextFromPDF, validatePdfFile, initPdfJs } from './pdf-service';
 
 // Interfaces for structured output
 export interface StudentGrades {
@@ -65,12 +65,7 @@ async function parseGradeTable(
     }
     
     // Load PDF with pdfjs
-    // Make sure the worker is properly loaded
-    const workerSrc = "https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.4.120/pdf.worker.min.js";
-    
-    if (!pdfjs.GlobalWorkerOptions.workerSrc) {
-      pdfjs.GlobalWorkerOptions.workerSrc = workerSrc;
-    }
+    initPdfJs();
     
     // Ajout d'un timeout pour éviter un blocage indéfini
     const timeoutPromise = new Promise<never>((_, reject) => {

--- a/src/utils/pdf-service.ts
+++ b/src/utils/pdf-service.ts
@@ -1,7 +1,8 @@
 import * as pdfjs from 'pdfjs-dist';
+import { PDFJS_WORKER_URL } from './pdfjs-worker';
 
 // Set the worker source for PDF.js
-const PDFJS_CDN_URL = "https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.4.120";
+const PDFJS_CDN_URL = PDFJS_WORKER_URL.replace('/pdf.worker.min.js', '');
 
 /**
  * Initialize PDF.js worker
@@ -9,7 +10,7 @@ const PDFJS_CDN_URL = "https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.4.120";
 export function initPdfJs(forceReinit: boolean = false): void {
   if (forceReinit || !pdfjs.GlobalWorkerOptions.workerSrc) {
     console.info("PDF.js worker initialized from CDN");
-    pdfjs.GlobalWorkerOptions.workerSrc = `${PDFJS_CDN_URL}/pdf.worker.min.js`;
+    pdfjs.GlobalWorkerOptions.workerSrc = PDFJS_WORKER_URL;
   }
 }
 

--- a/src/utils/pdfTableExtractor.ts
+++ b/src/utils/pdfTableExtractor.ts
@@ -1,4 +1,5 @@
 import * as pdfjs from 'pdfjs-dist';
+import { PDFJS_WORKER_URL } from './pdfjs-worker';
 
 export async function extractGradesTable(pdfBuffer: ArrayBuffer) {
   try {
@@ -6,7 +7,7 @@ export async function extractGradesTable(pdfBuffer: ArrayBuffer) {
     
     // Initialize PDF.js
     if (!pdfjs.GlobalWorkerOptions.workerSrc) {
-      pdfjs.GlobalWorkerOptions.workerSrc = "https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.4.120/pdf.worker.min.js";
+      pdfjs.GlobalWorkerOptions.workerSrc = PDFJS_WORKER_URL;
     }
     
     // Load the PDF document

--- a/src/utils/pdfjs-worker.ts
+++ b/src/utils/pdfjs-worker.ts
@@ -1,0 +1,2 @@
+export const PDFJS_VERSION = '5.0.375';
+export const PDFJS_WORKER_URL = `https://cdnjs.cloudflare.com/ajax/libs/pdf.js/${PDFJS_VERSION}/pdf.worker.min.js`;


### PR DESCRIPTION
## Summary
- centralize PDF.js worker URL
- use worker URL when initializing pdf-service
- rely on shared init in pdf-processing
- load shared worker in pdfTableExtractor

## Testing
- `bun run build`

------
https://chatgpt.com/codex/tasks/task_e_6842f3de9410832993f5dfb676d12c28